### PR TITLE
Fixed a bug when expansion symbol is disabled

### DIFF
--- a/py/templates.py
+++ b/py/templates.py
@@ -1050,7 +1050,8 @@ class RetroTemplate(ClassicTemplate):
             offset += 4
 
         self.text_layer_type.translate(0, offset)
-        self.expansion_symbol_layer.translate(0, offset)
+        if self.expansion_symbol_layer:
+            self.expansion_symbol_layer.translate(0, offset)
         if self.color_indicator_layer:
             self.color_indicator_layer.translate(0, offset)
 

--- a/py/templates.py
+++ b/py/templates.py
@@ -1046,7 +1046,8 @@ class RetroTemplate(ClassicTemplate):
                 offset = 0
 
         if self.has_pinlines:
-            self.expansion_symbol_layer.resize(90, 90, AnchorPosition.MiddleCenter)
+            if self.expansion_symbol_layer:
+                self.expansion_symbol_layer.resize(90, 90, AnchorPosition.MiddleCenter)
             offset += 4
 
         self.text_layer_type.translate(0, offset)


### PR DESCRIPTION
I'm not into Proxyshop development that much, but basically, what happens when someone disables the expansion symbol is getting this error:
`self.expansion_symbol_layer.translate(0, offset) - AttributeError: 'NoneType' object has no attribute 'translate'`
I added a check for it being not None before the translation, and it now works like a charm.