### PR TITLE
fix(RetroTemplate): Default textbox_size cfg to "Automatic" when ini …

### DIFF
--- a/py/templates.py
+++ b/py/templates.py
@@ -74,6 +74,7 @@ class RetroTemplate(NormalTemplate):
         return CFG.get_setting(
             section="GENERAL",
             key="textbox_size",
+            default="Automatic",
             is_bool=False)
 
     @property


### PR DESCRIPTION
CFG.get_setting returns None when an option is absent from the .ini file, which propagated through textbox_size and caused every consumer (art_reference, bevel masks, etc.) to crash with NoneType errors.